### PR TITLE
 feature/task-06/spark-articles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,22 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: corretto
           java-version: 17
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+
       - name: Build with Gradle
         run: ./gradlew build
+
+      - name: Upload reports
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports
+          path: build/reports

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,10 +11,17 @@ plugins {
 
 dependencies {
     testImplementation(libs.junit.jupiter)
-
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.mockito:mockito-core:5.14.2")
+    testImplementation("org.mockito:mockito-junit-jupiter:5.14.2")
 
     compileOnly("org.jetbrains:annotations:25.0.0")
+
+    implementation("org.slf4j:slf4j-api:2.0.16")
+    implementation("ch.qos.logback:logback-classic:1.5.12")
+
+    implementation("com.sparkjava:spark-core:2.9.4")
+    implementation("com.sparkjava:spark-template-freemarker:2.7.1")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.18.1")
 }
 
 
@@ -71,11 +78,11 @@ tasks.jacocoTestCoverageVerification {
             limit {
                 counter = "LINE"
                 value = "COVEREDRATIO"
-                minimum = BigDecimal.valueOf(0.55)
+                minimum = BigDecimal.valueOf(0.6)
             }
         }
     }
 }
 
 
-version = "1.4"
+version = "1.6"

--- a/src/main/java/me/kruase/mipt/api/Application.java
+++ b/src/main/java/me/kruase/mipt/api/Application.java
@@ -1,0 +1,19 @@
+package me.kruase.mipt.api;
+
+
+import me.kruase.mipt.api.controllers.Controller;
+
+import java.util.List;
+
+
+public final class Application {
+    private final List<Controller> controllers;
+
+    public Application(List<Controller> controllers) {
+        this.controllers = controllers;
+    }
+
+    public void start() {
+        controllers.forEach(Controller::initializeEndpoints);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/controllers/ArticleController.java
+++ b/src/main/java/me/kruase/mipt/api/controllers/ArticleController.java
@@ -1,0 +1,171 @@
+package me.kruase.mipt.api.controllers;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.kruase.mipt.api.entities.article.ArticleService;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleCreateException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleDeleteException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleFindException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleUpdateException;
+import me.kruase.mipt.api.entities.article.models.Article;
+import me.kruase.mipt.api.schemas.request.ArticleCreateRequest;
+import me.kruase.mipt.api.schemas.request.ArticleUpdateRequest;
+import me.kruase.mipt.api.schemas.response.CreateResponse;
+import me.kruase.mipt.api.schemas.response.ErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Service;
+
+
+public final class ArticleController implements Controller {
+    private static final Logger LOG = LoggerFactory.getLogger(ArticleController.class);
+
+    private final String routePrefix;
+    private final Service service;
+    private final ArticleService articleService;
+    private final ObjectMapper objectMapper;
+
+
+    public ArticleController(
+            String routePrefix,
+            Service service, ArticleService articleService, ObjectMapper objectMapper
+    ) {
+        this.routePrefix = routePrefix;
+        this.service = service;
+        this.articleService = articleService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void initializeEndpoints() {
+        getAllArticles();
+        getArticle();
+        createArticle();
+        updateArticle();
+        deleteArticle();
+    }
+
+    private void getAllArticles() {
+        service.get(
+                routePrefix,
+                (request, response) -> {
+                    response.type("application/json");
+
+                    LOG.debug("Successfully found all articles");
+
+                    response.status(200);
+                    return objectMapper.writeValueAsString(articleService.findAll());
+                }
+        );
+    }
+
+    private void getArticle() {
+        service.get(
+                routePrefix + "/:id",
+                (request, response) -> {
+                    response.type("application/json");
+
+                    long articleId = Long.parseLong(request.params("id"));
+
+                    try {
+                        Article article = articleService.findById(articleId);
+
+                        LOG.debug("Successfully found article by id={}", articleId);
+
+                        response.status(200);
+                        return objectMapper.writeValueAsString(article);
+                    } catch (ArticleFindException e) {
+                        LOG.warn("Error getting article by id={}", articleId, e);
+
+                        response.status(404);
+                        return objectMapper.writeValueAsString(new ErrorResponse(e));
+                    }
+                }
+        );
+    }
+
+    private void createArticle() {
+        service.post(
+                routePrefix,
+                (request, response) -> {
+                    response.type("application/json");
+
+                    ArticleCreateRequest articleCreateRequest =
+                            objectMapper.readValue(request.body(), ArticleCreateRequest.class);
+
+                    try {
+                        long articleId = articleService.create(
+                                articleCreateRequest.title(),
+                                articleCreateRequest.tags()
+                        );
+
+                        LOG.debug("Successfully created article with id={}", articleId);
+
+                        response.status(201);
+                        return objectMapper.writeValueAsString(new CreateResponse(articleId));
+                    } catch (ArticleCreateException e) {
+                        LOG.warn("Error creating article", e);
+
+                        response.status(400);
+                        return objectMapper.writeValueAsString(new ErrorResponse(e));
+                    }
+                }
+        );
+    }
+
+    private void updateArticle() {
+        service.put(
+                routePrefix + "/:id",
+                (request, response) -> {
+                    response.type("application/json");
+
+                    long articleId = Long.parseLong(request.params("id"));
+                    ArticleUpdateRequest articleUpdateRequest =
+                            objectMapper.readValue(request.body(), ArticleUpdateRequest.class);
+
+                    try {
+                        articleService.update(
+                                articleId,
+                                articleUpdateRequest.title(),
+                                articleUpdateRequest.tags()
+                        );
+
+                        LOG.debug("Successfully updated article by id={}", articleId);
+
+                        response.status(204);
+                        return "";
+                    } catch (ArticleUpdateException e) {
+                        LOG.warn("Error updating article by id={}", articleId, e);
+
+                        response.status(404);
+                        return objectMapper.writeValueAsString(new ErrorResponse(e));
+                    }
+                }
+        );
+    }
+
+    private void deleteArticle() {
+        service.delete(
+                routePrefix + "/:id",
+                (request, response) -> {
+                    response.type("application/json");
+
+                    long articleId = Long.parseLong(request.params("id"));
+
+                    try {
+                        articleService.delete(articleId);
+
+                        LOG.debug("Successfully deleted article by id={}", articleId);
+
+                        response.status(204);
+                        return "";
+                    } catch (ArticleDeleteException e) {
+                        LOG.warn("Error deleting article by id={}", articleId, e);
+
+                        response.status(404);
+                        return objectMapper.writeValueAsString(new ErrorResponse(e));
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/controllers/CommentController.java
+++ b/src/main/java/me/kruase/mipt/api/controllers/CommentController.java
@@ -1,0 +1,124 @@
+package me.kruase.mipt.api.controllers;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.kruase.mipt.api.entities.comment.CommentService;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentCreateException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentDeleteException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentFindException;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.schemas.request.CommentCreateRequest;
+import me.kruase.mipt.api.schemas.response.CreateResponse;
+import me.kruase.mipt.api.schemas.response.ErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Service;
+
+
+public final class CommentController implements Controller {
+    private static final Logger LOG = LoggerFactory.getLogger(CommentController.class);
+
+    private final String routePrefix;
+    private final Service service;
+    private final CommentService commentService;
+    private final ObjectMapper objectMapper;
+
+    public CommentController(
+            String routePrefix,
+            Service service, CommentService commentService, ObjectMapper objectMapper
+    ) {
+        this.routePrefix = routePrefix;
+        this.service = service;
+        this.commentService = commentService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void initializeEndpoints() {
+        getComment();
+        createComment();
+        deleteComment();
+    }
+
+    private void getComment() {
+        service.get(
+                routePrefix + "/:id",
+                (request, response) -> {
+                    response.type("application/json");
+
+                    long commentId = Long.parseLong(request.params("id"));
+
+                    try {
+                        Comment comment = commentService.findById(commentId);
+
+                        LOG.debug("Successfully found comment by id={}", commentId);
+
+                        response.status(200);
+                        return objectMapper.writeValueAsString(comment);
+                    } catch (CommentFindException e) {
+                        LOG.warn("Error getting comment by id={}", commentId, e);
+
+                        response.status(404);
+                        return objectMapper.writeValueAsString(new ErrorResponse(e));
+                    }
+                }
+        );
+    }
+
+    private void createComment() {
+        service.post(
+                routePrefix,
+                (request, response) -> {
+                    response.type("application/json");
+
+                    CommentCreateRequest commentCreateRequest =
+                            objectMapper.readValue(request.body(), CommentCreateRequest.class);
+
+                    try {
+                        long commentId = commentService.create(
+                                commentCreateRequest.articleId(),
+                                commentCreateRequest.content()
+                        );
+
+                        LOG.debug(
+                                "Successfully added new comment with id={} to article with id={}",
+                                commentId, commentCreateRequest.articleId()
+                        );
+
+                        response.status(201);
+                        return objectMapper.writeValueAsString(new CreateResponse(commentId));
+                    } catch (CommentCreateException e) {
+                        LOG.warn("Error creating comment", e);
+
+                        response.status(400);
+                        return objectMapper.writeValueAsString(new ErrorResponse(e));
+                    }
+                }
+        );
+    }
+
+    private void deleteComment() {
+        service.delete(
+                routePrefix + "/:id",
+                (request, response) -> {
+                    response.type("application/json");
+
+                    long commentId = Long.parseLong(request.params("id"));
+
+                    try {
+                        commentService.delete(commentId);
+
+                        LOG.debug("Successfully deleted comment with id={}", commentId);
+
+                        response.status(204);
+                        return "";
+                    } catch (CommentDeleteException e) {
+                        LOG.warn("Error deleting comment by id={}", commentId, e);
+
+                        response.status(404);
+                        return objectMapper.writeValueAsString(new ErrorResponse(e));
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/controllers/Controller.java
+++ b/src/main/java/me/kruase/mipt/api/controllers/Controller.java
@@ -1,0 +1,6 @@
+package me.kruase.mipt.api.controllers;
+
+
+public interface Controller {
+    void initializeEndpoints();
+}

--- a/src/main/java/me/kruase/mipt/api/controllers/FreemarkerController.java
+++ b/src/main/java/me/kruase/mipt/api/controllers/FreemarkerController.java
@@ -1,0 +1,72 @@
+package me.kruase.mipt.api.controllers;
+
+
+import me.kruase.mipt.api.entities.article.ArticleService;
+import me.kruase.mipt.api.entities.article.models.Article;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.ModelAndView;
+import spark.Request;
+import spark.Response;
+import spark.Service;
+import spark.template.freemarker.FreeMarkerEngine;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public final class FreemarkerController implements Controller {
+    private static final Logger LOG = LoggerFactory.getLogger(FreemarkerController.class);
+
+    private final String route;
+    private final Service service;
+    private final ArticleService articleService;
+    private final FreeMarkerEngine freeMarkerEngine;
+
+    public FreemarkerController(
+            String route,
+            Service service,
+            ArticleService articleService,
+            FreeMarkerEngine freeMarkerEngine
+    ) {
+        this.route = route;
+        this.service = service;
+        this.articleService = articleService;
+        this.freeMarkerEngine = freeMarkerEngine;
+    }
+
+    @Override
+    public void initializeEndpoints() {
+        getArticleTable();
+    }
+
+    private void getArticleTable() {
+        service.get(
+                route,
+                (Request request, Response response) -> {
+                    response.type("text/html; charset=utf-8");
+
+                    List<Article> articles = articleService.findAll();
+                    List<Map<String, String>> articleMapList =
+                            articles.stream()
+                                    .map(article ->
+                                            Map.of(
+                                                    "id", article.id().toString(),
+                                                    "title", article.title(),
+                                                    "tags", String.join(" ", article.tags()),
+                                                    "comment_count",
+                                                    String.valueOf(article.comments().size())
+                                            )
+                                    )
+                                    .toList();
+
+                    LOG.debug("Successfully rendered article table");
+
+                    Map<String, Object> model = new HashMap<>();
+                    model.put("articles", articleMapList);
+                    return freeMarkerEngine.render(new ModelAndView(model, "index.ftl"));
+                }
+        );
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/ArticleService.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/ArticleService.java
@@ -1,0 +1,77 @@
+package me.kruase.mipt.api.entities.article;
+
+
+import me.kruase.mipt.api.entities.article.exceptions.ArticleConflictException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleCreateException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleDeleteException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleFindException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleNotFoundException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleUpdateException;
+import me.kruase.mipt.api.entities.article.models.Article;
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.article.models.NewArticle;
+import me.kruase.mipt.api.entities.article.repositories.ArticleRepository;
+
+import java.util.List;
+import java.util.Set;
+
+
+public final class ArticleService {
+    private final ArticleRepository articleRepository;
+
+    public ArticleService(ArticleRepository articleRepository) {
+        this.articleRepository = articleRepository;
+    }
+
+    public List<Article> findAll() {
+        return articleRepository.findAll();
+    }
+
+    public Article findById(long articleId) throws ArticleFindException {
+        ArticleId articleIdObject = new ArticleId(articleId);
+
+        try {
+            return articleRepository.findById(articleIdObject);
+        } catch (ArticleNotFoundException e) {
+            throw new ArticleFindException(articleIdObject, e);
+        }
+    }
+
+    public long create(String title, Set<String> tags) throws ArticleCreateException {
+        try {
+            return articleRepository.create(new NewArticle(title, tags)).value();
+        } catch (ArticleConflictException e) {
+            throw new ArticleCreateException(e);
+        }
+    }
+
+    public void update(long articleId, String title, Set<String> tags)
+            throws ArticleUpdateException {
+        Article article;
+        try {
+            article = findById(articleId);
+        } catch (ArticleFindException e) {
+            throw new ArticleUpdateException(new ArticleId(articleId), e);
+        }
+
+        try {
+            articleRepository.update(
+                    article
+                            .withTitle(title)
+                            .withTags(tags)
+            );
+        } catch (ArticleNotFoundException e) {
+            throw new ArticleUpdateException(article.id(), e);
+        }
+    }
+
+    public void delete(long articleId) throws ArticleDeleteException {
+        ArticleId articleIdObject = new ArticleId(articleId);
+
+        try {
+            articleRepository.delete(articleIdObject);
+        } catch (ArticleNotFoundException e) {
+            throw new ArticleDeleteException(articleIdObject, e);
+        }
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleConflictException.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleConflictException.java
@@ -1,0 +1,13 @@
+package me.kruase.mipt.api.entities.article.exceptions;
+
+
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+
+
+public class ArticleConflictException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "Article with id=%s already exists";
+
+    public ArticleConflictException(ArticleId articleId) {
+        super(String.format(DEFAULT_MESSAGE, articleId));
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleCreateException.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleCreateException.java
@@ -1,0 +1,10 @@
+package me.kruase.mipt.api.entities.article.exceptions;
+
+
+public class ArticleCreateException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "Cannot create article";
+
+    public ArticleCreateException(Throwable cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleDeleteException.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleDeleteException.java
@@ -1,0 +1,13 @@
+package me.kruase.mipt.api.entities.article.exceptions;
+
+
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+
+
+public class ArticleDeleteException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "Cannot delete article with id=%s";
+
+    public ArticleDeleteException(ArticleId articleId, Throwable cause) {
+        super(String.format(DEFAULT_MESSAGE, articleId), cause);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleFindException.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleFindException.java
@@ -1,0 +1,13 @@
+package me.kruase.mipt.api.entities.article.exceptions;
+
+
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+
+
+public class ArticleFindException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "Cannot find article with id=%s";
+
+    public ArticleFindException(ArticleId articleId, Throwable cause) {
+        super(String.format(DEFAULT_MESSAGE, articleId), cause);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleNotFoundException.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleNotFoundException.java
@@ -1,0 +1,14 @@
+package me.kruase.mipt.api.entities.article.exceptions;
+
+
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+
+
+public class ArticleNotFoundException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "Article with id=%s does not exist";
+
+    public ArticleNotFoundException(ArticleId articleId) {
+        super(String.format(DEFAULT_MESSAGE, articleId));
+    }
+
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleUpdateException.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/exceptions/ArticleUpdateException.java
@@ -1,0 +1,13 @@
+package me.kruase.mipt.api.entities.article.exceptions;
+
+
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+
+
+public class ArticleUpdateException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "Cannot update article with id=%s";
+
+    public ArticleUpdateException(ArticleId articleId, Throwable cause) {
+        super(String.format(DEFAULT_MESSAGE, articleId), cause);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/models/Article.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/models/Article.java
@@ -1,0 +1,52 @@
+package me.kruase.mipt.api.entities.article.models;
+
+
+import me.kruase.mipt.api.entities.comment.models.Comment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+
+public record Article(ArticleId id, String title, Set<String> tags, List<Comment> comments) {
+    public Article(ArticleId id, NewArticle newArticle) {
+        this(id, newArticle.title(), newArticle.tags(), List.of());
+    }
+
+    public Article withTitle(String newTitle) {
+        return new Article(id, newTitle, tags, comments);
+    }
+
+    public Article withTags(Set<String> newTags) {
+        return new Article(id, title, newTags, comments);
+    }
+
+    public Article addComment(Comment comment) {
+        List<Comment> newComments = new ArrayList<>(comments);
+        newComments.add(comment);
+
+        return new Article(id, title, tags, newComments);
+    }
+
+    public Article removeComment(Comment comment) {
+        List<Comment> newComments = new ArrayList<>(comments);
+        newComments.remove(comment);
+
+        return new Article(id, title, tags, newComments);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Article article)) {
+            return false;
+        }
+
+        return Objects.equals(id, article.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/models/ArticleId.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/models/ArticleId.java
@@ -1,0 +1,14 @@
+package me.kruase.mipt.api.entities.article.models;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import me.kruase.mipt.api.util.EntityId;
+import me.kruase.mipt.api.util.LongEntityIdSerializer;
+
+
+@JsonSerialize(using = LongEntityIdSerializer.class)
+public final class ArticleId extends EntityId<Long> {
+    public ArticleId(long value) {
+        super(value);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/models/NewArticle.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/models/NewArticle.java
@@ -1,0 +1,11 @@
+package me.kruase.mipt.api.entities.article.models;
+
+
+import java.util.Set;
+
+
+/**
+ * DTO for creating a new {@link Article}, without {@code articleId} field
+ */
+public record NewArticle(String title, Set<String> tags) {
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/repositories/ArticleRepository.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/repositories/ArticleRepository.java
@@ -1,0 +1,28 @@
+package me.kruase.mipt.api.entities.article.repositories;
+
+
+import me.kruase.mipt.api.entities.article.exceptions.ArticleConflictException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleNotFoundException;
+import me.kruase.mipt.api.entities.article.models.Article;
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.article.models.NewArticle;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+
+import java.util.List;
+
+
+public interface ArticleRepository {
+    List<Article> findAll();
+
+    Article findById(ArticleId articleId) throws ArticleNotFoundException;
+
+    ArticleId create(NewArticle newArticle) throws ArticleConflictException;
+
+    void update(Article article) throws ArticleNotFoundException;
+
+    void delete(ArticleId articleId) throws ArticleNotFoundException;
+
+    void addComment(ArticleId articleId, Comment comment) throws ArticleNotFoundException;
+
+    void removeComment(ArticleId articleId, Comment comment) throws ArticleNotFoundException;
+}

--- a/src/main/java/me/kruase/mipt/api/entities/article/repositories/InMemoryArticleRepository.java
+++ b/src/main/java/me/kruase/mipt/api/entities/article/repositories/InMemoryArticleRepository.java
@@ -1,0 +1,105 @@
+package me.kruase.mipt.api.entities.article.repositories;
+
+
+import me.kruase.mipt.api.entities.article.exceptions.ArticleConflictException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleNotFoundException;
+import me.kruase.mipt.api.entities.article.models.Article;
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.article.models.NewArticle;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.entities.comment.repositories.CommentRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public final class InMemoryArticleRepository implements ArticleRepository {
+    private final AtomicLong lastId = new AtomicLong(0);
+    private final Map<ArticleId, Article> storage = new ConcurrentHashMap<>();
+
+    private final CommentRepository commentRepository;
+
+    /**
+     * @param commentRepository needed to simulate {@code ON DELETE ...} SQL behavior
+     *                          as {@link Comment}
+     *                          is dependent on {@link Article}
+     */
+    public InMemoryArticleRepository(CommentRepository commentRepository) {
+        this.commentRepository = commentRepository;
+    }
+
+    private ArticleId generateId() {
+        return new ArticleId(lastId.incrementAndGet());
+    }
+
+    @Override
+    public List<Article> findAll() {
+        return List.copyOf(storage.values());
+    }
+
+    @Override
+    public Article findById(ArticleId articleId) throws ArticleNotFoundException {
+        Article article = storage.get(articleId);
+
+        if (article == null) {
+            throw new ArticleNotFoundException(articleId);
+        }
+
+        return article;
+    }
+
+    @Override
+    public synchronized ArticleId create(NewArticle newArticle) throws ArticleConflictException {
+        ArticleId articleId = generateId();
+
+        if (storage.get(articleId) != null) {
+            throw new ArticleConflictException(articleId);
+        }
+
+        Article article = new Article(articleId, newArticle);
+
+        storage.put(articleId, article);
+
+        return articleId;
+    }
+
+    @Override
+    public synchronized void update(Article article) throws ArticleNotFoundException {
+        if (storage.get(article.id()) == null) {
+            throw new ArticleNotFoundException(article.id());
+        }
+
+        storage.put(article.id(), article);
+    }
+
+    @Override
+    public synchronized void delete(ArticleId articleId) throws ArticleNotFoundException {
+        if (storage.remove(articleId) == null) {
+            throw new ArticleNotFoundException(articleId);
+        }
+
+        commentRepository.deleteAllByArticleId(articleId);
+    }
+
+    @Override
+    public synchronized void addComment(ArticleId articleId, Comment comment)
+            throws ArticleNotFoundException {
+        Article article = findById(articleId);
+
+        Article newArticle = article.addComment(comment);
+
+        storage.put(articleId, newArticle);
+    }
+
+    @Override
+    public synchronized void removeComment(ArticleId articleId, Comment comment)
+            throws ArticleNotFoundException {
+        Article article = findById(articleId);
+
+        Article newArticle = article.removeComment(comment);
+
+        storage.put(articleId, newArticle);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/comment/CommentService.java
+++ b/src/main/java/me/kruase/mipt/api/entities/comment/CommentService.java
@@ -1,0 +1,105 @@
+package me.kruase.mipt.api.entities.comment;
+
+
+import me.kruase.mipt.api.entities.article.exceptions.ArticleNotFoundException;
+import me.kruase.mipt.api.entities.article.models.Article;
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.article.repositories.ArticleRepository;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentConflictException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentCreateException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentDeleteException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentFindException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentNotFoundException;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+import me.kruase.mipt.api.entities.comment.models.NewComment;
+import me.kruase.mipt.api.entities.comment.repositories.CommentRepository;
+
+
+public final class CommentService {
+    private final CommentRepository commentRepository;
+    private final ArticleRepository articleRepository;
+
+    /**
+     * @param articleRepository needed to add comments to and remove them from
+     *                          the {@link Article} entities...
+     *                          (weird requirement tbh)
+     */
+    public CommentService(
+            CommentRepository commentRepository, ArticleRepository articleRepository
+    ) {
+        this.commentRepository = commentRepository;
+        this.articleRepository = articleRepository;
+    }
+
+    public Comment findById(long commentId) throws CommentFindException {
+        CommentId commentIdObject = new CommentId(commentId);
+
+        try {
+            return commentRepository.findById(commentIdObject);
+        } catch (CommentNotFoundException e) {
+            throw new CommentFindException(commentIdObject, e);
+        }
+    }
+
+    public long create(long articleId, String content) throws CommentCreateException {
+        ArticleId articleIdObject = new ArticleId(articleId);
+
+        CommentId commentIdObject;
+        try {
+            commentIdObject = commentRepository.create(new NewComment(articleIdObject, content));
+        } catch (CommentConflictException e) {
+            throw new CommentCreateException(e);
+        }
+
+        Comment comment;
+        try {
+            comment = findById(commentIdObject.value());
+        } catch (CommentFindException e) {
+            throw new CommentCreateException(e);
+        }
+
+        try {
+            articleRepository.addComment(articleIdObject, comment);
+        } catch (ArticleNotFoundException e) {
+            // reverting...
+            try {
+                commentRepository.delete(comment.id());
+            } catch (CommentNotFoundException inner) {
+                throw new CommentCreateException(inner);
+            }
+
+            throw new CommentCreateException(e);
+        }
+
+        return commentIdObject.value();
+    }
+
+    public void delete(long commentId) throws CommentDeleteException {
+        Comment comment;
+        try {
+            comment = findById(commentId);
+        } catch (CommentFindException e) {
+            throw new CommentDeleteException(new CommentId(commentId), e);
+        }
+
+        try {
+            articleRepository.removeComment(comment.articleId(), comment);
+        } catch (ArticleNotFoundException e) {
+            throw new CommentDeleteException(comment.id(), e);
+        }
+
+        try {
+            commentRepository.delete(comment.id());
+        } catch (CommentNotFoundException e) {
+            // reverting...
+            try {
+                articleRepository.addComment(comment.articleId(), comment);
+            } catch (ArticleNotFoundException inner) {
+                throw new CommentDeleteException(comment.id(), inner);
+            }
+
+            throw new CommentDeleteException(comment.id(), e);
+        }
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/comment/exceptions/CommentConflictException.java
+++ b/src/main/java/me/kruase/mipt/api/entities/comment/exceptions/CommentConflictException.java
@@ -1,0 +1,13 @@
+package me.kruase.mipt.api.entities.comment.exceptions;
+
+
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+
+
+public class CommentConflictException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "Comment with id=%s already exists";
+
+    public CommentConflictException(CommentId commentId) {
+        super(String.format(DEFAULT_MESSAGE, commentId));
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/comment/exceptions/CommentCreateException.java
+++ b/src/main/java/me/kruase/mipt/api/entities/comment/exceptions/CommentCreateException.java
@@ -1,0 +1,10 @@
+package me.kruase.mipt.api.entities.comment.exceptions;
+
+
+public class CommentCreateException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "Cannot create comment";
+
+    public CommentCreateException(Throwable cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/comment/exceptions/CommentDeleteException.java
+++ b/src/main/java/me/kruase/mipt/api/entities/comment/exceptions/CommentDeleteException.java
@@ -1,0 +1,13 @@
+package me.kruase.mipt.api.entities.comment.exceptions;
+
+
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+
+
+public class CommentDeleteException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "Cannot delete comment with id=%s";
+
+    public CommentDeleteException(CommentId commentId, Throwable cause) {
+        super(String.format(DEFAULT_MESSAGE, commentId), cause);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/comment/exceptions/CommentFindException.java
+++ b/src/main/java/me/kruase/mipt/api/entities/comment/exceptions/CommentFindException.java
@@ -1,0 +1,13 @@
+package me.kruase.mipt.api.entities.comment.exceptions;
+
+
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+
+
+public class CommentFindException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "Cannot find comment with id=%s";
+
+    public CommentFindException(CommentId commentId, Throwable cause) {
+        super(String.format(DEFAULT_MESSAGE, commentId), cause);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/comment/exceptions/CommentNotFoundException.java
+++ b/src/main/java/me/kruase/mipt/api/entities/comment/exceptions/CommentNotFoundException.java
@@ -1,0 +1,14 @@
+package me.kruase.mipt.api.entities.comment.exceptions;
+
+
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+
+
+public class CommentNotFoundException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "Comment with id=%s does not exist";
+
+    public CommentNotFoundException(CommentId commentId) {
+        super(String.format(DEFAULT_MESSAGE, commentId));
+    }
+
+}

--- a/src/main/java/me/kruase/mipt/api/entities/comment/models/Comment.java
+++ b/src/main/java/me/kruase/mipt/api/entities/comment/models/Comment.java
@@ -1,0 +1,32 @@
+package me.kruase.mipt.api.entities.comment.models;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+
+import java.util.Objects;
+
+
+public record Comment(
+        CommentId id,
+        @JsonProperty("article_id") ArticleId articleId,
+        String content
+) {
+    public Comment(CommentId id, NewComment newComment) {
+        this(id, newComment.articleId(), newComment.content());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Comment comment)) {
+            return false;
+        }
+
+        return Objects.equals(id, comment.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/comment/models/CommentId.java
+++ b/src/main/java/me/kruase/mipt/api/entities/comment/models/CommentId.java
@@ -1,0 +1,14 @@
+package me.kruase.mipt.api.entities.comment.models;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import me.kruase.mipt.api.util.EntityId;
+import me.kruase.mipt.api.util.LongEntityIdSerializer;
+
+
+@JsonSerialize(using = LongEntityIdSerializer.class)
+public final class CommentId extends EntityId<Long> {
+    public CommentId(long value) {
+        super(value);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/entities/comment/models/NewComment.java
+++ b/src/main/java/me/kruase/mipt/api/entities/comment/models/NewComment.java
@@ -1,0 +1,11 @@
+package me.kruase.mipt.api.entities.comment.models;
+
+
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+
+
+/**
+ * DTO for creating a new {@link Comment}, without {@code commentId} field
+ */
+public record NewComment(ArticleId articleId, String content) {
+}

--- a/src/main/java/me/kruase/mipt/api/entities/comment/repositories/CommentRepository.java
+++ b/src/main/java/me/kruase/mipt/api/entities/comment/repositories/CommentRepository.java
@@ -1,0 +1,21 @@
+package me.kruase.mipt.api.entities.comment.repositories;
+
+
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentConflictException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentNotFoundException;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+import me.kruase.mipt.api.entities.comment.models.NewComment;
+
+
+public interface CommentRepository {
+    Comment findById(CommentId commentId) throws CommentNotFoundException;
+
+    CommentId create(NewComment comment) throws CommentConflictException;
+
+    void delete(CommentId commentId) throws CommentNotFoundException;
+
+    void deleteAllByArticleId(ArticleId articleId);
+
+}

--- a/src/main/java/me/kruase/mipt/api/entities/comment/repositories/InMemoryCommentRepository.java
+++ b/src/main/java/me/kruase/mipt/api/entities/comment/repositories/InMemoryCommentRepository.java
@@ -1,0 +1,61 @@
+package me.kruase.mipt.api.entities.comment.repositories;
+
+
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentConflictException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentNotFoundException;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+import me.kruase.mipt.api.entities.comment.models.NewComment;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public final class InMemoryCommentRepository implements CommentRepository {
+    private final AtomicLong lastId = new AtomicLong(0);
+    private final Map<CommentId, Comment> storage = new ConcurrentHashMap<>();
+
+    private CommentId generateId() {
+        return new CommentId(lastId.incrementAndGet());
+    }
+
+    @Override
+    public Comment findById(CommentId commentId) throws CommentNotFoundException {
+        Comment comment = storage.get(commentId);
+
+        if (comment == null) {
+            throw new CommentNotFoundException(commentId);
+        }
+
+        return comment;
+    }
+
+    @Override
+    public synchronized CommentId create(NewComment comment) throws CommentConflictException {
+        CommentId commentId = generateId();
+
+        if (storage.get(commentId) != null) {
+            throw new CommentConflictException(commentId);
+        }
+
+        Comment newComment = new Comment(commentId, comment);
+
+        storage.put(commentId, newComment);
+
+        return commentId;
+    }
+
+    @Override
+    public void delete(CommentId commentId) throws CommentNotFoundException {
+        if (storage.remove(commentId) == null) {
+            throw new CommentNotFoundException(commentId);
+        }
+    }
+
+    @Override
+    public void deleteAllByArticleId(ArticleId articleId) {
+        storage.values().removeIf(comment -> comment.articleId().equals(articleId));
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/schemas/request/ArticleCreateRequest.java
+++ b/src/main/java/me/kruase/mipt/api/schemas/request/ArticleCreateRequest.java
@@ -1,0 +1,8 @@
+package me.kruase.mipt.api.schemas.request;
+
+
+import java.util.Set;
+
+
+public record ArticleCreateRequest(String title, Set<String> tags) {
+}

--- a/src/main/java/me/kruase/mipt/api/schemas/request/ArticleUpdateRequest.java
+++ b/src/main/java/me/kruase/mipt/api/schemas/request/ArticleUpdateRequest.java
@@ -1,0 +1,8 @@
+package me.kruase.mipt.api.schemas.request;
+
+
+import java.util.Set;
+
+
+public record ArticleUpdateRequest(String title, Set<String> tags) {
+}

--- a/src/main/java/me/kruase/mipt/api/schemas/request/CommentCreateRequest.java
+++ b/src/main/java/me/kruase/mipt/api/schemas/request/CommentCreateRequest.java
@@ -1,0 +1,8 @@
+package me.kruase.mipt.api.schemas.request;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public record CommentCreateRequest(@JsonProperty("article_id") long articleId, String content) {
+}

--- a/src/main/java/me/kruase/mipt/api/schemas/response/CreateResponse.java
+++ b/src/main/java/me/kruase/mipt/api/schemas/response/CreateResponse.java
@@ -1,0 +1,5 @@
+package me.kruase.mipt.api.schemas.response;
+
+
+public record CreateResponse(long id) {
+}

--- a/src/main/java/me/kruase/mipt/api/schemas/response/ErrorResponse.java
+++ b/src/main/java/me/kruase/mipt/api/schemas/response/ErrorResponse.java
@@ -1,0 +1,21 @@
+package me.kruase.mipt.api.schemas.response;
+
+
+public record ErrorResponse(String error, String detail) {
+    public ErrorResponse(Throwable t) {
+        this(t.getMessage(), getInitialCauseMessage(t));
+    }
+
+    private static String getInitialCauseMessage(Throwable t) {
+        if (t.getCause() == null) {
+            return null;
+        }
+
+        Throwable currentThrowable = t.getCause();
+        while (currentThrowable.getCause() != null) {
+            currentThrowable = currentThrowable.getCause();
+        }
+
+        return currentThrowable.getMessage();
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/util/EntityId.java
+++ b/src/main/java/me/kruase/mipt/api/util/EntityId.java
@@ -1,0 +1,39 @@
+package me.kruase.mipt.api.util;
+
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+
+public abstract class EntityId<T> {
+    private final @NotNull T value;
+
+    public EntityId(@NotNull T value) {
+        this.value = value;
+    }
+
+    public @NotNull T value() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        EntityId<?> entityId = (EntityId<?>) o;
+        return value.equals(entityId.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/util/LongEntityIdSerializer.java
+++ b/src/main/java/me/kruase/mipt/api/util/LongEntityIdSerializer.java
@@ -1,0 +1,21 @@
+package me.kruase.mipt.api.util;
+
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+
+public final class LongEntityIdSerializer extends StdSerializer<EntityId<Long>> {
+    public LongEntityIdSerializer() {
+        super((Class<EntityId<Long>>) null);
+    }
+
+    @Override
+    public void serialize(EntityId<Long> value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+        gen.writeNumber(value.value());
+    }
+}

--- a/src/main/java/me/kruase/mipt/api/util/TemplateFactory.java
+++ b/src/main/java/me/kruase/mipt/api/util/TemplateFactory.java
@@ -1,0 +1,17 @@
+package me.kruase.mipt.api.util;
+
+
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.template.Configuration;
+import me.kruase.mipt.Main;
+import spark.template.freemarker.FreeMarkerEngine;
+
+
+public final class TemplateFactory {
+    public static FreeMarkerEngine freeMarkerEngine() {
+        Configuration freeMarkerConfiguration = new Configuration(Configuration.VERSION_2_3_0);
+        FreeMarkerEngine freeMarkerEngine = new FreeMarkerEngine(freeMarkerConfiguration);
+        freeMarkerConfiguration.setTemplateLoader(new ClassTemplateLoader(Main.class, "/"));
+        return freeMarkerEngine;
+    }
+}

--- a/src/main/resources/index.ftl
+++ b/src/main/resources/index.ftl
@@ -1,0 +1,32 @@
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Главная страница</title>
+  <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/gh/yegor256/tacit@gh-pages/tacit-css.min.css"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+</head>
+
+<body>
+
+<h1>Статьи</h1>
+<table>
+  <tr>
+    <th>ID</th>
+    <th>Заголовок</th>
+    <th>Теги</th>
+    <th>Количество комментариев</th>
+  </tr>
+    <#list articles as article>
+      <tr>
+        <td>${article.id}</td>
+        <td>${article.title}</td>
+        <td>${article.tags?replace(" ", "<br>")}</td>
+        <td>${article.comment_count}</td>
+      </tr>
+    </#list>
+</table>
+
+</body>
+
+</html>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>
+        %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+      </Pattern>
+    </layout>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+
+</configuration>

--- a/src/test/java/me/kruase/mipt/api/ApplicationTest.java
+++ b/src/test/java/me/kruase/mipt/api/ApplicationTest.java
@@ -1,0 +1,165 @@
+package me.kruase.mipt.api;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.kruase.mipt.api.controllers.ArticleController;
+import me.kruase.mipt.api.controllers.CommentController;
+import me.kruase.mipt.api.controllers.FreemarkerController;
+import me.kruase.mipt.api.entities.article.ArticleService;
+import me.kruase.mipt.api.entities.article.models.Article;
+import me.kruase.mipt.api.entities.article.repositories.ArticleRepository;
+import me.kruase.mipt.api.entities.article.repositories.InMemoryArticleRepository;
+import me.kruase.mipt.api.entities.comment.CommentService;
+import me.kruase.mipt.api.entities.comment.repositories.CommentRepository;
+import me.kruase.mipt.api.entities.comment.repositories.InMemoryCommentRepository;
+import me.kruase.mipt.api.schemas.response.CreateResponse;
+import me.kruase.mipt.api.util.SimpleHttpClient;
+import me.kruase.mipt.api.util.TemplateFactory;
+import org.junit.jupiter.api.Test;
+import spark.Service;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class ApplicationTest {
+    static final String globalPrefix = "/test";
+    static final String apiPrefix = globalPrefix + "/api";
+
+    @Test
+    void testEndToEnd() throws IOException, InterruptedException {
+        // Setup
+        Service service = Service.ignite();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        CommentRepository commentRepository = new InMemoryCommentRepository();
+        ArticleRepository articleRepository = new InMemoryArticleRepository(commentRepository);
+
+        ArticleService articleService = new ArticleService(articleRepository);
+        CommentService commentService = new CommentService(commentRepository, articleRepository);
+
+        ArticleController articleController = new ArticleController(
+                apiPrefix + "/articles",
+                service,
+                articleService,
+                objectMapper
+        );
+        CommentController commentController = new CommentController(
+                apiPrefix + "/comments",
+                service,
+                commentService,
+                objectMapper
+        );
+        FreemarkerController freemarkerController = new FreemarkerController(
+                globalPrefix,
+                service,
+                articleService,
+                TemplateFactory.freeMarkerEngine()
+        );
+
+        Application application = new Application(
+                List.of(
+                        articleController,
+                        commentController,
+                        freemarkerController
+                )
+        );
+
+        application.start();
+        service.awaitInitialization();
+
+        String baseUrl = "http://localhost:" + service.port() + globalPrefix;
+        String apiUrl = "http://localhost:" + service.port() + apiPrefix;
+        SimpleHttpClient client = new SimpleHttpClient();
+
+        // Constants
+        String title = "title";
+        String titleUpdated = "title_updated";
+        String tag1 = "tag_1";
+        String tag1Updated = "tag_1_updated";
+        String tag2 = "tag_2";
+        String tag2Updated = "tag_2_updated";
+        String content = "content";
+
+        // Test
+        HttpResponse<String> articleCreateHttpResponse = client.post(
+                apiUrl + "/articles",
+                """
+                        {
+                          "title": "%s",
+                          "tags": ["%s", "%s"]
+                        }
+                        """.formatted(title, tag1, tag2)
+        );
+        long articleId =
+                objectMapper.readValue(articleCreateHttpResponse.body(), CreateResponse.class).id();
+
+        HttpResponse<String> commentCreateHttpResponse = client.post(
+                apiUrl + "/comments",
+                """
+                        {
+                          "article_id": "%d",
+                          "content": "%s"
+                        }
+                        """.formatted(articleId, content)
+        );
+        long commentId =
+                objectMapper.readValue(commentCreateHttpResponse.body(), CreateResponse.class).id();
+
+        HttpResponse<String> articleGetHttpResponse =
+                client.get(apiUrl + "/articles/" + articleId);
+        Article article = objectMapper.readValue(articleGetHttpResponse.body(), Article.class);
+
+        assertEquals(title, article.title());
+        assertEquals(Set.of(tag1, tag2), article.tags());
+        assertEquals(1, article.comments().size());
+        assertEquals(commentId, article.comments().get(0).id().value());
+        assertEquals(content, article.comments().get(0).content());
+
+        HttpResponse<String> htmlResponse = client.get(baseUrl);
+        String htmlResponseContent = htmlResponse.body();
+
+        assertTrue(htmlResponseContent.contains(String.valueOf(articleId)));
+        assertTrue(htmlResponseContent.contains(title));
+        assertTrue(htmlResponseContent.contains(tag1));
+        assertTrue(htmlResponseContent.contains(tag2));
+        assertTrue(htmlResponseContent.contains(String.valueOf(article.comments().size())));
+
+        client.put(
+                apiUrl + "/articles/" + articleId,
+                """
+                        {
+                          "title": "%s",
+                          "tags": ["%s", "%s"]
+                        }
+                        """.formatted(titleUpdated, tag1Updated, tag2Updated)
+        );
+
+        client.delete(apiUrl + "/comments/" + commentId);
+
+        articleGetHttpResponse = client.get(apiUrl + "/articles/" + articleId);
+        article = objectMapper.readValue(articleGetHttpResponse.body(), Article.class);
+
+        assertEquals(titleUpdated, article.title());
+        assertEquals(Set.of(tag1Updated, tag2Updated), article.tags());
+        assertEquals(0, article.comments().size());
+
+        htmlResponse = client.get(baseUrl);
+        htmlResponseContent = htmlResponse.body();
+
+        assertTrue(htmlResponseContent.contains(String.valueOf(articleId)));
+        assertTrue(htmlResponseContent.contains(titleUpdated));
+        assertTrue(htmlResponseContent.contains(tag1Updated));
+        assertTrue(htmlResponseContent.contains(tag2Updated));
+        assertTrue(htmlResponseContent.contains(String.valueOf(article.comments().size())));
+
+        // Shutdown
+        service.stop();
+        service.awaitStop();
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/controllers/ArticleControllerTest.java
+++ b/src/test/java/me/kruase/mipt/api/controllers/ArticleControllerTest.java
@@ -1,0 +1,239 @@
+package me.kruase.mipt.api.controllers;
+
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.kruase.mipt.api.Application;
+import me.kruase.mipt.api.entities.article.ArticleService;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleCreateException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleDeleteException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleFindException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleUpdateException;
+import me.kruase.mipt.api.entities.article.models.Article;
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.article.models.ArticleTest;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+import me.kruase.mipt.api.schemas.response.CreateResponse;
+import me.kruase.mipt.api.util.SimpleHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import spark.Service;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@ExtendWith(MockitoExtension.class)
+class ArticleControllerTest {
+    static final String routePrefix = "/test/api/articles";
+
+    Service service;
+    ObjectMapper objectMapper;
+    Application application;
+    SimpleHttpClient client;
+    String baseUrl;
+
+    @Mock
+    ArticleService articleService;
+
+    Article article1;
+    Article article2;
+    Article updatedArticle;
+
+    @BeforeEach
+    void setUp() {
+        service = Service.ignite();
+
+        objectMapper = new ObjectMapper();
+        application = new Application(
+                List.of(
+                        new ArticleController(
+                                routePrefix,
+                                service,
+                                articleService,
+                                objectMapper
+                        )
+                )
+        );
+
+        application.start();
+        service.awaitInitialization();
+
+        baseUrl = "http://localhost:" + service.port() + routePrefix;
+        client = new SimpleHttpClient();
+
+        ArticleId articleId1 = new ArticleId(123);
+        ArticleId articleId2 = new ArticleId(456);
+
+        article1 = new Article(
+                articleId1,
+                "title_1",
+                Set.of("tag_1", "tag_2"),
+                List.of(
+                        new Comment(new CommentId(123), articleId1, "content_1"),
+                        new Comment(new CommentId(456), articleId1, "content_2")
+                )
+        );
+        article2 = new Article(
+                articleId2,
+                "title_2",
+                Set.of("tag_3", "tag_4"),
+                List.of(
+                        new Comment(new CommentId(789), articleId2, "content_3")
+                )
+        );
+        updatedArticle = new Article(
+                articleId1,
+                "title_1_updated",
+                Set.of("tag_1_updated", "tag_2_updated"),
+                article1.comments()
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        service.stop();
+        service.awaitStop();
+    }
+
+    @Test
+    void testGetAllArticles200() throws IOException, InterruptedException {
+        List<Article> articles = List.of(article1, article2);
+        Mockito.when(articleService.findAll()).thenReturn(articles);
+
+        HttpResponse<String> response = client.get(baseUrl);
+
+        assertEquals(200, response.statusCode());
+        List<Article> responseArticles =
+                objectMapper.readValue(response.body(), new TypeReference<>() {});
+        ArticleTest.assertDeepEqualsMany(articles, responseArticles);
+    }
+
+    @Test
+    void testGetArticle200() throws IOException, InterruptedException {
+        Mockito.when(articleService.findById(article1.id().value()))
+                .thenReturn(article1);
+
+        HttpResponse<String> response = client.get(baseUrl + "/" + article1.id().value());
+
+        assertEquals(200, response.statusCode());
+        Article responseArticle = objectMapper.readValue(response.body(), Article.class);
+        ArticleTest.assertDeepEquals(article1, responseArticle);
+    }
+
+    @Test
+    void testGetArticle404() throws IOException, InterruptedException {
+        Mockito.when(articleService.findById(article1.id().value()))
+                .thenThrow(ArticleFindException.class);
+
+        HttpResponse<String> response = client.get(baseUrl + "/" + article1.id().value());
+
+        assertEquals(404, response.statusCode());
+    }
+
+    @Test
+    void testCreateArticle201() throws IOException, InterruptedException {
+        Mockito.when(articleService.create(article1.title(), article1.tags()))
+                .thenReturn(article1.id().value());
+
+        HttpResponse<String> response = client.post(
+                baseUrl,
+                """
+                        {
+                          "title": "title_1",
+                          "tags": ["tag_1", "tag_2"]
+                        }
+                        """
+        );
+
+        assertEquals(201, response.statusCode());
+        CreateResponse createdArticleId =
+                objectMapper.readValue(response.body(), CreateResponse.class);
+        assertEquals(article1.id().value(), createdArticleId.id());
+    }
+
+    @Test
+    void testCreateArticle400() throws IOException, InterruptedException {
+        Mockito.when(articleService.create(article1.title(), article1.tags()))
+                .thenThrow(ArticleCreateException.class);
+
+        HttpResponse<String> response = client.post(
+                baseUrl,
+                """
+                        {
+                          "title": "title_1",
+                          "tags": ["tag_1", "tag_2"]
+                        }
+                        """
+        );
+
+        assertEquals(400, response.statusCode());
+    }
+
+    @Test
+    void testUpdateArticle204() throws IOException, InterruptedException {
+        Mockito.doNothing()
+                .when(articleService)
+                .update(article1.id().value(), updatedArticle.title(), updatedArticle.tags());
+
+        HttpResponse<String> response = client.put(
+                baseUrl + "/" + article1.id().value(),
+                """
+                        {
+                          "title": "title_1_updated",
+                          "tags": ["tag_1_updated", "tag_2_updated"]
+                        }
+                        """
+        );
+
+        assertEquals(204, response.statusCode());
+    }
+
+    @Test
+    void testUpdateArticle404() throws IOException, InterruptedException {
+        Mockito.doThrow(ArticleUpdateException.class)
+                .when(articleService)
+                .update(article1.id().value(), updatedArticle.title(), updatedArticle.tags());
+
+        HttpResponse<String> response = client.put(
+                baseUrl + "/" + article1.id().value(),
+                """
+                        {
+                          "title": "title_1_updated",
+                          "tags": ["tag_1_updated", "tag_2_updated"]
+                        }
+                        """
+        );
+
+        assertEquals(404, response.statusCode());
+    }
+
+    @Test
+    void testDeleteArticle204() throws IOException, InterruptedException {
+        Mockito.doNothing().when(articleService).delete(article1.id().value());
+
+        HttpResponse<String> response = client.delete(baseUrl + "/" + article1.id().value());
+
+        assertEquals(204, response.statusCode());
+    }
+
+    @Test
+    void testDeleteArticle404() throws IOException, InterruptedException {
+        Mockito.doThrow(ArticleDeleteException.class)
+                .when(articleService).delete(article1.id().value());
+
+        HttpResponse<String> response = client.delete(baseUrl + "/" + article1.id().value());
+
+        assertEquals(404, response.statusCode());
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/controllers/CommentControllerTest.java
+++ b/src/test/java/me/kruase/mipt/api/controllers/CommentControllerTest.java
@@ -1,0 +1,158 @@
+package me.kruase.mipt.api.controllers;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.kruase.mipt.api.Application;
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.comment.CommentService;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentCreateException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentDeleteException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentFindException;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+import me.kruase.mipt.api.entities.comment.models.CommentTest;
+import me.kruase.mipt.api.schemas.response.CreateResponse;
+import me.kruase.mipt.api.util.SimpleHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import spark.Service;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@ExtendWith(MockitoExtension.class)
+class CommentControllerTest {
+    static final String routePrefix = "/test/api/comments";
+
+    Service service;
+    ObjectMapper objectMapper;
+    Application application;
+    SimpleHttpClient client;
+    String baseUrl;
+
+    Comment comment;
+
+    @Mock
+    CommentService commentService;
+
+    @BeforeEach
+    void setUp() {
+        service = Service.ignite();
+
+        objectMapper = new ObjectMapper();
+        application = new Application(
+                List.of(
+                        new CommentController(
+                                routePrefix,
+                                service,
+                                commentService,
+                                objectMapper
+                        )
+                )
+        );
+
+        application.start();
+        service.awaitInitialization();
+
+        baseUrl = "http://localhost:" + service.port() + routePrefix;
+        client = new SimpleHttpClient();
+
+        comment = new Comment(
+                new CommentId(123),
+                new ArticleId(456),
+                "content"
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        service.stop();
+        service.awaitStop();
+    }
+
+    @Test
+    void tesGetComment200() throws IOException, InterruptedException {
+        Mockito.when(commentService.findById(comment.id().value())).thenReturn(comment);
+
+        HttpResponse<String> response = client.get(baseUrl + "/" + comment.id().value());
+
+        assertEquals(200, response.statusCode());
+        Comment responseComment = objectMapper.readValue(response.body(), Comment.class);
+        CommentTest.assertDeepEquals(comment, responseComment);
+    }
+
+    @Test
+    void testGetComment404() throws IOException, InterruptedException {
+        Mockito.when(commentService.findById(comment.id().value()))
+                .thenThrow(CommentFindException.class);
+
+        HttpResponse<String> response = client.get(baseUrl + "/" + comment.id().value());
+
+        assertEquals(404, response.statusCode());
+    }
+
+    @Test
+    void testCreateComment201() throws IOException, InterruptedException {
+        Mockito.when(commentService.create(comment.articleId().value(), comment.content()))
+                .thenReturn(comment.id().value());
+
+        HttpResponse<String> response = client.post(
+                baseUrl, """
+                        {
+                          "article_id": 456,
+                          "content": "content"
+                        }
+                        """
+        );
+
+        assertEquals(201, response.statusCode());
+        CreateResponse createResponse =
+                objectMapper.readValue(response.body(), CreateResponse.class);
+        assertEquals(comment.id().value(), createResponse.id());
+    }
+
+    @Test
+    void testCreateComment400() throws IOException, InterruptedException {
+        Mockito.when(commentService.create(comment.articleId().value(), comment.content()))
+                .thenThrow(CommentCreateException.class);
+
+        HttpResponse<String> response = client.post(
+                baseUrl, """
+                        {
+                          "article_id": 456,
+                          "content": "content"
+                        }
+                        """
+        );
+
+        assertEquals(400, response.statusCode());
+    }
+
+    @Test
+    void testDeleteComment204() throws IOException, InterruptedException {
+        Mockito.doNothing().when(commentService).delete(comment.id().value());
+
+        HttpResponse<String> response = client.delete(baseUrl + "/" + comment.id().value());
+
+        assertEquals(204, response.statusCode());
+    }
+
+    @Test
+    void testDeleteComment404() throws IOException, InterruptedException {
+        Mockito.doThrow(CommentDeleteException.class)
+                .when(commentService).delete(comment.id().value());
+
+        HttpResponse<String> response = client.delete(baseUrl + "/" + comment.id().value());
+
+        assertEquals(404, response.statusCode());
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/controllers/FreemarkerControllerTest.java
+++ b/src/test/java/me/kruase/mipt/api/controllers/FreemarkerControllerTest.java
@@ -1,0 +1,98 @@
+package me.kruase.mipt.api.controllers;
+
+
+import me.kruase.mipt.api.Application;
+import me.kruase.mipt.api.entities.article.ArticleService;
+import me.kruase.mipt.api.entities.article.models.Article;
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+import me.kruase.mipt.api.util.SimpleHttpClient;
+import me.kruase.mipt.api.util.TemplateFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import spark.Service;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@ExtendWith(MockitoExtension.class)
+class FreemarkerControllerTest {
+    static final String route = "/test";
+
+    Service service;
+    Application application;
+    SimpleHttpClient client;
+    String baseUrl;
+
+    @Mock
+    ArticleService articleService;
+
+    Article article;
+
+    @BeforeEach
+    void setUp() {
+        service = Service.ignite();
+
+        application = new Application(
+                List.of(
+                        new FreemarkerController(
+                                route,
+                                service,
+                                articleService,
+                                TemplateFactory.freeMarkerEngine()
+                        )
+                )
+        );
+
+        application.start();
+        service.awaitInitialization();
+
+        baseUrl = "http://localhost:" + service.port() + route;
+        client = new SimpleHttpClient();
+
+        ArticleId articleId = new ArticleId(123);
+        article = new Article(
+                articleId,
+                "title",
+                Set.of("tag_1", "tag_2"),
+                List.of(
+                        new Comment(
+                                new CommentId(456),
+                                articleId,
+                                "content_1"
+                        ),
+                        new Comment(
+                                new CommentId(789),
+                                articleId,
+                                "content_2"
+                        )
+                )
+        );
+    }
+
+    @Test
+    void testGetArticleTable200() throws IOException, InterruptedException {
+        Mockito.when(articleService.findAll()).thenReturn(List.of(article));
+
+        HttpResponse<String> response = client.get(baseUrl);
+        String responseContent = response.body();
+
+        assertTrue(responseContent.contains(article.id().toString()));
+        assertTrue(responseContent.contains(article.title()));
+        assertTrue(
+                article.tags().stream()
+                        .allMatch(responseContent::contains)
+        );
+        assertTrue(responseContent.contains(String.valueOf(article.comments().size())));
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/entities/article/ArticleServiceTest.java
+++ b/src/test/java/me/kruase/mipt/api/entities/article/ArticleServiceTest.java
@@ -1,0 +1,156 @@
+package me.kruase.mipt.api.entities.article;
+
+
+import me.kruase.mipt.api.entities.article.exceptions.ArticleConflictException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleCreateException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleDeleteException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleFindException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleNotFoundException;
+import me.kruase.mipt.api.entities.article.exceptions.ArticleUpdateException;
+import me.kruase.mipt.api.entities.article.models.Article;
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.article.models.ArticleTest;
+import me.kruase.mipt.api.entities.article.models.NewArticle;
+import me.kruase.mipt.api.entities.article.repositories.ArticleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+    @Mock
+    ArticleRepository articleRepository;
+
+    @InjectMocks
+    ArticleService service;
+
+    NewArticle newArticle1;
+    Article article1;
+    Article article2;
+    Article updateArticle1;
+
+    @BeforeEach
+    void setUp() {
+        newArticle1 = new NewArticle("title_1", Set.of("tag_1", "tag_2"));
+        NewArticle newArticle2 = new NewArticle("title_2", Set.of("tag_3", "tag_4"));
+
+        article1 = new Article(new ArticleId(123), newArticle1);
+        article2 = new Article(new ArticleId(456), newArticle2);
+        updateArticle1 = new Article(article1.id(), newArticle2);
+    }
+
+    @Test
+    void testFindAll() {
+        List<Article> articles = List.of(article1, article2);
+        Mockito.when(articleRepository.findAll()).thenReturn(articles);
+
+        List<Article> foundArticles = service.findAll();
+
+        Mockito.verify(articleRepository).findAll();
+        ArticleTest.assertDeepEqualsMany(foundArticles, articles);
+    }
+
+    @Test
+    void testFindById() {
+        Mockito.when(articleRepository.findById(article1.id())).thenReturn(article1);
+
+        Article foundArticle = service.findById(article1.id().value());
+
+        Mockito.verify(articleRepository).findById(article1.id());
+        ArticleTest.assertDeepEquals(foundArticle, article1);
+    }
+
+    @Test
+    void testFindByIdThrows() {
+        Mockito.when(articleRepository.findById(article1.id()))
+                .thenThrow(ArticleNotFoundException.class);
+
+        assertThrows(
+                ArticleFindException.class,
+                () -> service.findById(article1.id().value())
+        );
+        Mockito.verify(articleRepository).findById(article1.id());
+    }
+
+    @Test
+    void testCreate() {
+        Mockito.when(articleRepository.create(newArticle1)).thenReturn(article1.id());
+
+        long createdArticleId = service.create(newArticle1.title(), newArticle1.tags());
+
+        Mockito.verify(articleRepository).create(newArticle1);
+        assertEquals(createdArticleId, article1.id().value());
+    }
+
+    @Test
+    void testCreateThrows() {
+        Mockito.when(articleRepository.create(newArticle1))
+                .thenThrow(ArticleConflictException.class);
+
+        assertThrows(
+                ArticleCreateException.class,
+                () -> service.create(newArticle1.title(), newArticle1.tags())
+        );
+        Mockito.verify(articleRepository).create(newArticle1);
+    }
+
+    @Test
+    void testUpdate() {
+        Mockito.when(articleRepository.findById(article1.id())).thenReturn(article1);
+        Mockito.doNothing().when(articleRepository).update(updateArticle1);
+
+        service.update(article1.id().value(), updateArticle1.title(), updateArticle1.tags());
+
+        Mockito.verify(articleRepository).findById(article1.id());
+        Mockito.verify(articleRepository).update(updateArticle1);
+    }
+
+    @Test
+    void testUpdateThrows() {
+        Mockito.when(articleRepository.findById(article1.id())).thenReturn(article1);
+        Mockito.doThrow(ArticleNotFoundException.class)
+                .when(articleRepository).update(updateArticle1);
+
+        assertThrows(
+                ArticleUpdateException.class,
+                () -> service.update(
+                        article1.id().value(),
+                        updateArticle1.title(),
+                        updateArticle1.tags()
+                )
+        );
+        Mockito.verify(articleRepository).update(updateArticle1);
+    }
+
+    @Test
+    void testDelete() {
+        Mockito.doNothing().when(articleRepository).delete(article1.id());
+
+        service.delete(article1.id().value());
+
+        Mockito.verify(articleRepository).delete(article1.id());
+    }
+
+    @Test
+    void testDeleteThrows() {
+        Mockito.doThrow(ArticleNotFoundException.class)
+                .when(articleRepository).delete(article1.id());
+
+        assertThrows(
+                ArticleDeleteException.class,
+                () -> service.delete(article1.id().value())
+        );
+        Mockito.verify(articleRepository).delete(article1.id());
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/entities/article/models/ArticleTest.java
+++ b/src/test/java/me/kruase/mipt/api/entities/article/models/ArticleTest.java
@@ -1,0 +1,161 @@
+package me.kruase.mipt.api.entities.article.models;
+
+
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+import me.kruase.mipt.api.entities.comment.models.CommentTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+public class ArticleTest {
+    ArticleId articleId;
+    Article article;
+
+    @BeforeEach
+    void setUp() {
+        articleId = new ArticleId(123);
+        article = new Article(
+                articleId,
+                "title",
+                Set.of("tag_1", "tag_2"),
+                List.of(
+                        new Comment(
+                                new CommentId(123),
+                                articleId,
+                                "comment_1"
+                        ),
+                        new Comment(
+                                new CommentId(456),
+                                articleId,
+                                "comment_2"
+                        )
+                )
+        );
+    }
+
+    @Test
+    void testArticleCreation() {
+        NewArticle newArticle = new NewArticle("new_title", Set.of("tag_3", "tag_4"));
+
+        Article createdArticle = new Article(articleId, newArticle);
+
+        assertEquals(articleId, createdArticle.id());
+        assertEquals(newArticle.title(), createdArticle.title());
+        assertEquals(newArticle.tags(), createdArticle.tags());
+        assertIterableEquals(List.of(), createdArticle.comments());
+    }
+
+    @Test
+    void testWithTitle() {
+        String newTitle = "new_title";
+
+        Article newArticle = article.withTitle(newTitle);
+
+        assertEquals(article.id(), newArticle.id());
+        assertEquals(newTitle, newArticle.title());
+        assertEquals(article.tags(), newArticle.tags());
+        assertEquals(article.comments(), newArticle.comments());
+    }
+
+    @Test
+    void testWithTags() {
+        Set<String> newTags = Set.of("tag_3", "tag_4");
+
+        Article newArticle = article.withTags(newTags);
+
+        assertEquals(article.id(), newArticle.id());
+        assertEquals(article.title(), newArticle.title());
+        assertEquals(newTags, newArticle.tags());
+        assertEquals(article.comments(), newArticle.comments());
+    }
+
+    @Test
+    void testAddComment() {
+        Comment addedComment = new Comment(
+                new CommentId(789),
+                articleId,
+                "comment_3"
+        );
+
+        Article newArticle = article.addComment(addedComment);
+
+        ArrayList<Comment> newCommentList = new ArrayList<>(article.comments());
+        newCommentList.add(addedComment);
+
+        assertEquals(article.id(), newArticle.id());
+        assertEquals(article.title(), newArticle.title());
+        assertEquals(article.tags(), newArticle.tags());
+        assertIterableEquals(newCommentList, newArticle.comments());
+    }
+
+    @Test
+    void testRemoveComment() {
+        Comment removedComment = article.comments().get(0);
+
+        Article newArticle = article.removeComment(removedComment);
+
+        ArrayList<Comment> newCommentList = new ArrayList<>(article.comments());
+        newCommentList.remove(removedComment);
+
+        assertEquals(article.id(), newArticle.id());
+        assertEquals(article.title(), newArticle.title());
+        assertEquals(article.tags(), newArticle.tags());
+        assertIterableEquals(newCommentList, newArticle.comments());
+    }
+
+    public static void assertDeepEquals(Article expected, Article actual) {
+        if (expected == actual) {
+            return;
+        }
+
+        assertNotNull(expected);
+        assertNotNull(actual);
+
+        assertEquals(expected.id(), actual.id());
+        assertEquals(expected.title(), actual.title());
+        assertEquals(expected.tags(), actual.tags());
+
+        CommentTest.assertDeepEqualsMany(expected.comments(), actual.comments());
+    }
+
+    public static void assertDeepNotEquals(Article expected, Article actual) {
+        assertThrows(
+                AssertionFailedError.class,
+                () -> assertDeepEquals(expected, actual)
+        );
+    }
+
+    public static void assertDeepEqualsMany(
+            Iterable<Article> expectedIterable, Iterable<Article> actualIterable
+    ) {
+        if (expectedIterable == actualIterable) {
+            return;
+        }
+
+        assertNotNull(expectedIterable);
+        assertNotNull(actualIterable);
+
+        Iterator<Article> expectedIterator = expectedIterable.iterator();
+        Iterator<Article> actualIterator = actualIterable.iterator();
+
+        while (expectedIterator.hasNext() && actualIterator.hasNext()) {
+            assertDeepEquals(expectedIterator.next(), actualIterator.next());
+        }
+
+        assertFalse(expectedIterator.hasNext());
+        assertFalse(actualIterator.hasNext());
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/entities/article/repositories/ArticleRepositoryTest.java
+++ b/src/test/java/me/kruase/mipt/api/entities/article/repositories/ArticleRepositoryTest.java
@@ -1,0 +1,193 @@
+package me.kruase.mipt.api.entities.article.repositories;
+
+
+import me.kruase.mipt.api.entities.article.exceptions.ArticleNotFoundException;
+import me.kruase.mipt.api.entities.article.models.Article;
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.article.models.ArticleTest;
+import me.kruase.mipt.api.entities.article.models.NewArticle;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+import me.kruase.mipt.api.entities.comment.models.CommentTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+public abstract class ArticleRepositoryTest<I extends ArticleRepository> {
+    I repository;
+
+    NewArticle newArticle1;
+    NewArticle newArticle2;
+    NewArticle newArticle3;
+    Article referenceArticle1;
+    Article referenceArticle2;
+    ArticleId invalidArticleId;
+
+    abstract I getImplementation();
+
+    @BeforeEach
+    void setUp() {
+        repository = getImplementation();
+
+        newArticle1 = new NewArticle("title_1", Set.of("tag_1", "tag_2"));
+        newArticle2 = new NewArticle("title_2", Set.of("tag_2", "tag_3"));
+        newArticle3 = new NewArticle("title_3", Set.of("tag_3", "tag_4"));
+
+        ArticleId articleId1 = repository.create(newArticle1);
+        ArticleId articleId2 = repository.create(newArticle2);
+
+        Comment comment1 = new Comment(new CommentId(123), articleId1, "comment_1");
+        Comment comment2 = new Comment(new CommentId(456), articleId1, "comment_2");
+        repository.addComment(articleId1, comment1);
+        repository.addComment(articleId1, comment2);
+
+        referenceArticle1 = new Article(articleId1, newArticle1);
+        referenceArticle1 = referenceArticle1.addComment(comment1);
+        referenceArticle1 = referenceArticle1.addComment(comment2);
+
+        referenceArticle2 = new Article(articleId2, newArticle2);
+
+        invalidArticleId = new ArticleId(0);
+    }
+
+    @Test
+    void testFindAll() {
+        List<Article> allArticles = repository.findAll();
+
+        ArticleTest.assertDeepEqualsMany(
+                allArticles, List.of(referenceArticle1, referenceArticle2)
+        );
+    }
+
+    @Test
+    void testFindById() {
+        Article foundArticle1 = repository.findById(referenceArticle1.id());
+        Article foundArticle2 = repository.findById(referenceArticle2.id());
+
+        ArticleTest.assertDeepEquals(foundArticle1, referenceArticle1);
+        ArticleTest.assertDeepEquals(foundArticle2, referenceArticle2);
+    }
+
+    @Test
+    void testFindByIdThrows() {
+        assertThrows(
+                ArticleNotFoundException.class,
+                () -> repository.findById(invalidArticleId)
+        );
+    }
+
+    @Test
+    void testCreate() {
+        ArticleId createdArticleId = repository.create(newArticle3);
+
+        // test id increment: referenceArticle2 was the last created article
+        assertEquals(createdArticleId.value(), referenceArticle2.id().value() + 1);
+
+        Article foundArticle = repository.findById(createdArticleId);
+
+        ArticleTest.assertDeepEquals(foundArticle, new Article(createdArticleId, newArticle3));
+    }
+
+    @Test
+    void testUpdate() {
+        Article updateArticle = new Article(referenceArticle1.id(), newArticle3);
+
+        repository.update(updateArticle);
+
+        Article updatedArticle1 = repository.findById(referenceArticle1.id());
+
+        ArticleTest.assertDeepEquals(updatedArticle1, updateArticle);
+
+        // articles would be equal if compared by id only, but not if compared deeply
+        assertEquals(updatedArticle1, referenceArticle1);
+        ArticleTest.assertDeepNotEquals(updatedArticle1, referenceArticle1);
+    }
+
+    @Test
+    void testUpdateThrows() {
+        Article updateArticle = new Article(invalidArticleId, newArticle3);
+
+        assertThrows(
+                ArticleNotFoundException.class,
+                () -> repository.update(updateArticle)
+        );
+    }
+
+    @Test
+    void testDelete() {
+        repository.delete(referenceArticle1.id());
+
+        assertThrows(
+                ArticleNotFoundException.class,
+                () -> repository.findById(referenceArticle1.id())
+        );
+        assertDoesNotThrow(() -> repository.findById(referenceArticle2.id()));
+    }
+
+    @Test
+    void testDeleteThrows() {
+        assertThrows(
+                ArticleNotFoundException.class,
+                () -> repository.delete(invalidArticleId)
+        );
+    }
+
+    @Test
+    void testAddComment() {
+        Comment commentToAdd =
+                new Comment(new CommentId(789), referenceArticle1.id(), "comment_3");
+
+        repository.addComment(referenceArticle1.id(), commentToAdd);
+
+        Article updatedArticle1 = repository.findById(referenceArticle1.id());
+
+        assertEquals(updatedArticle1.comments().size(), referenceArticle1.comments().size() + 1);
+        CommentTest.assertDeepEquals(
+                updatedArticle1.comments().get(updatedArticle1.comments().size() - 1),
+                commentToAdd
+        );
+    }
+
+    @Test
+    void testAddCommentThrows() {
+        Comment commentToAdd =
+                new Comment(new CommentId(789), invalidArticleId, "comment_3");
+
+        assertThrows(
+                ArticleNotFoundException.class,
+                () -> repository.addComment(invalidArticleId, commentToAdd)
+        );
+    }
+
+    @Test
+    void testRemoveComment() {
+        Comment commentToDelete = referenceArticle1.comments().get(0);
+
+        repository.removeComment(referenceArticle1.id(), commentToDelete);
+
+        Article updatedArticle1 = repository.findById(referenceArticle1.id());
+
+        assertEquals(updatedArticle1.comments().size(), referenceArticle1.comments().size() - 1);
+        assertFalse(updatedArticle1.comments().contains(commentToDelete));
+    }
+
+
+    @Test
+    void testRemoveCommentThrows() {
+        Comment commentToRemove =
+                new Comment(new CommentId(789), invalidArticleId, "comment_3");
+
+        assertThrows(
+                ArticleNotFoundException.class,
+                () -> repository.removeComment(invalidArticleId, commentToRemove)
+        );
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/entities/article/repositories/InMemoryArticleRepositoryTest.java
+++ b/src/test/java/me/kruase/mipt/api/entities/article/repositories/InMemoryArticleRepositoryTest.java
@@ -1,0 +1,12 @@
+package me.kruase.mipt.api.entities.article.repositories;
+
+
+import me.kruase.mipt.api.entities.comment.repositories.InMemoryCommentRepository;
+
+
+class InMemoryArticleRepositoryTest extends ArticleRepositoryTest<InMemoryArticleRepository> {
+    @Override
+    InMemoryArticleRepository getImplementation() {
+        return new InMemoryArticleRepository(new InMemoryCommentRepository());
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/entities/comment/CommentServiceTest.java
+++ b/src/test/java/me/kruase/mipt/api/entities/comment/CommentServiceTest.java
@@ -1,0 +1,234 @@
+package me.kruase.mipt.api.entities.comment;
+
+
+import me.kruase.mipt.api.entities.article.exceptions.ArticleNotFoundException;
+import me.kruase.mipt.api.entities.article.models.Article;
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.article.models.NewArticle;
+import me.kruase.mipt.api.entities.article.repositories.ArticleRepository;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentConflictException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentCreateException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentDeleteException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentFindException;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentNotFoundException;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+import me.kruase.mipt.api.entities.comment.models.CommentTest;
+import me.kruase.mipt.api.entities.comment.models.NewComment;
+import me.kruase.mipt.api.entities.comment.repositories.CommentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+    @Mock
+    CommentRepository commentRepository;
+
+    @Mock
+    ArticleRepository articleRepository;
+
+    @InjectMocks
+    CommentService service;
+
+    Article article;
+    NewComment newComment;
+    Comment comment;
+
+    @BeforeEach
+    void setUp() {
+        article = new Article(
+                new ArticleId(123),
+                new NewArticle("title", Set.of("tag_1", "tag_2"))
+        );
+
+        newComment = new NewComment(article.id(), "content");
+        comment = new Comment(new CommentId(123), newComment);
+    }
+
+    @Test
+    void testFindById() {
+        Mockito.when(commentRepository.findById(comment.id())).thenReturn(comment);
+
+        Comment foundComment = service.findById(comment.id().value());
+
+        Mockito.verify(commentRepository).findById(comment.id());
+        CommentTest.assertDeepEquals(foundComment, comment);
+    }
+
+    @Test
+    void testFindByIdThrows() {
+        Mockito.when(commentRepository.findById(comment.id()))
+                .thenThrow(CommentNotFoundException.class);
+
+        assertThrows(
+                CommentFindException.class,
+                () -> service.findById(comment.id().value())
+        );
+        Mockito.verify(commentRepository).findById(comment.id());
+    }
+
+    @Test
+    void testCreate() {
+        Mockito.when(commentRepository.create(newComment)).thenReturn(comment.id());
+        Mockito.when(commentRepository.findById(comment.id())).thenReturn(comment);
+        Mockito.doNothing().when(articleRepository).addComment(article.id(), comment);
+
+        long createdCommentId =
+                service.create(newComment.articleId().value(), newComment.content());
+
+        Mockito.verify(commentRepository).create(newComment);
+        Mockito.verify(commentRepository).findById(comment.id());
+        Mockito.verify(articleRepository).addComment(comment.articleId(), comment);
+        assertEquals(createdCommentId, comment.id().value());
+    }
+
+    @Test
+    void testCreateThrows_DueToConflict() {
+        Mockito.when(commentRepository.create(newComment))
+                .thenThrow(CommentConflictException.class);
+
+        assertThrows(
+                CommentCreateException.class,
+                () -> service.create(newComment.articleId().value(), newComment.content())
+        );
+        Mockito.verify(commentRepository).create(newComment);
+    }
+
+    @Test
+    void testCreateThrows_DueToCommentNotFound() {
+        Mockito.when(commentRepository.create(newComment)).thenReturn(comment.id());
+        Mockito.when(commentRepository.findById(comment.id()))
+                .thenThrow(CommentNotFoundException.class);
+
+        assertThrows(
+                CommentCreateException.class,
+                () -> service.create(newComment.articleId().value(), newComment.content())
+        );
+        Mockito.verify(commentRepository).create(newComment);
+        Mockito.verify(commentRepository).findById(comment.id());
+    }
+
+    @Test
+    void testCreateThrows_DueToArticleNotFound() {
+        Mockito.when(commentRepository.create(newComment)).thenReturn(comment.id());
+        Mockito.when(commentRepository.findById(comment.id())).thenReturn(comment);
+        Mockito.doThrow(ArticleNotFoundException.class)
+                .when(articleRepository).addComment(article.id(), comment);
+        Mockito.doNothing().when(commentRepository).delete(comment.id());
+
+        assertThrows(
+                CommentCreateException.class,
+                () -> service.create(newComment.articleId().value(), newComment.content())
+        );
+        Mockito.verify(commentRepository).create(newComment);
+        Mockito.verify(commentRepository).findById(comment.id());
+        Mockito.verify(articleRepository).addComment(comment.articleId(), comment);
+        Mockito.verify(commentRepository).delete(comment.id());
+    }
+
+    @Test
+    void testCreateThrows_DueToArticleNotFound_AndCommentNotFound() {
+        Mockito.when(commentRepository.create(newComment)).thenReturn(comment.id());
+        Mockito.when(commentRepository.findById(comment.id())).thenReturn(comment);
+        Mockito.doThrow(ArticleNotFoundException.class)
+                .when(articleRepository).addComment(article.id(), comment);
+        Mockito.doThrow(CommentNotFoundException.class)
+                .when(commentRepository).delete(comment.id());
+
+        assertThrows(
+                CommentCreateException.class,
+                () -> service.create(newComment.articleId().value(), newComment.content())
+        );
+        Mockito.verify(commentRepository).create(newComment);
+        Mockito.verify(commentRepository).findById(comment.id());
+        Mockito.verify(articleRepository).addComment(comment.articleId(), comment);
+        Mockito.verify(commentRepository).delete(comment.id());
+    }
+
+    @Test
+    void testDelete() {
+        Mockito.when(commentRepository.findById(comment.id())).thenReturn(comment);
+        Mockito.doNothing().when(articleRepository).removeComment(article.id(), comment);
+        Mockito.doNothing().when(commentRepository).delete(comment.id());
+
+        service.delete(comment.id().value());
+
+        Mockito.verify(commentRepository).findById(comment.id());
+        Mockito.verify(articleRepository).removeComment(article.id(), comment);
+        Mockito.verify(commentRepository).delete(comment.id());
+    }
+
+    @Test
+    void testDeleteThrows_DueToCommentNotFound() {
+        Mockito.when(commentRepository.findById(comment.id()))
+                .thenThrow(CommentNotFoundException.class);
+
+        assertThrows(
+                CommentDeleteException.class,
+                () -> service.delete(comment.id().value())
+        );
+        Mockito.verify(commentRepository).findById(comment.id());
+    }
+
+    @Test
+    void testDeleteThrows_DueToArticleNotFound() {
+        Mockito.when(commentRepository.findById(comment.id())).thenReturn(comment);
+        Mockito.doThrow(ArticleNotFoundException.class)
+                .when(articleRepository).removeComment(article.id(), comment);
+
+        assertThrows(
+                CommentDeleteException.class,
+                () -> service.delete(comment.id().value())
+        );
+        Mockito.verify(commentRepository).findById(comment.id());
+        Mockito.verify(articleRepository).removeComment(article.id(), comment);
+    }
+
+    @Test
+    void testDeleteThrows_OnDelete_DueToCommentNotFound() {
+        Mockito.when(commentRepository.findById(comment.id())).thenReturn(comment);
+        Mockito.doNothing().when(articleRepository).removeComment(article.id(), comment);
+        Mockito.doThrow(CommentNotFoundException.class)
+                .when(commentRepository).delete(comment.id());
+        Mockito.doNothing().when(articleRepository).addComment(article.id(), comment);
+
+        assertThrows(
+                CommentDeleteException.class,
+                () -> service.delete(comment.id().value())
+        );
+        Mockito.verify(commentRepository).findById(comment.id());
+        Mockito.verify(articleRepository).removeComment(article.id(), comment);
+        Mockito.verify(commentRepository).delete(comment.id());
+        Mockito.verify(articleRepository).addComment(article.id(), comment);
+    }
+
+    @Test
+    void testDeleteThrows_OnDelete_DueToCommentNotFound_AndArticleNotFound() {
+        Mockito.when(commentRepository.findById(comment.id())).thenReturn(comment);
+        Mockito.doNothing().when(articleRepository).removeComment(article.id(), comment);
+        Mockito.doThrow(CommentNotFoundException.class)
+                .when(commentRepository).delete(comment.id());
+        Mockito.doThrow(ArticleNotFoundException.class)
+                .when(articleRepository).addComment(article.id(), comment);
+
+        assertThrows(
+                CommentDeleteException.class,
+                () -> service.delete(comment.id().value())
+        );
+        Mockito.verify(commentRepository).findById(comment.id());
+        Mockito.verify(articleRepository).removeComment(article.id(), comment);
+        Mockito.verify(commentRepository).delete(comment.id());
+        Mockito.verify(articleRepository).addComment(article.id(), comment);
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/entities/comment/models/CommentTest.java
+++ b/src/test/java/me/kruase/mipt/api/entities/comment/models/CommentTest.java
@@ -1,0 +1,60 @@
+package me.kruase.mipt.api.entities.comment.models;
+
+
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
+public class CommentTest {
+    @Test
+    void testCommentCreation() {
+        CommentId commentId = new CommentId(123);
+        NewComment newComment = new NewComment(new ArticleId(456), "content");
+
+        Comment createdComment = new Comment(commentId, newComment);
+
+        assertEquals(commentId, createdComment.id());
+        assertEquals(newComment.articleId(), createdComment.articleId());
+        assertEquals(newComment.content(), createdComment.content());
+    }
+
+    public static void assertDeepEquals(Comment expected, Comment actual) {
+        if (expected == actual) {
+            return;
+        }
+
+        assertNotNull(expected);
+        assertNotNull(actual);
+
+        assertEquals(expected.id(), actual.id());
+        assertEquals(expected.articleId(), actual.articleId());
+        assertEquals(expected.content(), actual.content());
+    }
+
+    public static void assertDeepEqualsMany(
+            Iterable<Comment> expectedIterable, Iterable<Comment> actualIterable
+    ) {
+        if (expectedIterable == actualIterable) {
+            return;
+        }
+
+        assertNotNull(expectedIterable);
+        assertNotNull(actualIterable);
+
+        Iterator<Comment> expectedIterator = expectedIterable.iterator();
+        Iterator<Comment> actualIterator = actualIterable.iterator();
+
+        while (expectedIterator.hasNext() && actualIterator.hasNext()) {
+            assertDeepEquals(expectedIterator.next(), actualIterator.next());
+        }
+
+        assertFalse(expectedIterator.hasNext());
+        assertFalse(actualIterator.hasNext());
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/entities/comment/repositories/CommentRepositoryTest.java
+++ b/src/test/java/me/kruase/mipt/api/entities/comment/repositories/CommentRepositoryTest.java
@@ -1,0 +1,118 @@
+package me.kruase.mipt.api.entities.comment.repositories;
+
+
+import me.kruase.mipt.api.entities.article.models.ArticleId;
+import me.kruase.mipt.api.entities.comment.exceptions.CommentNotFoundException;
+import me.kruase.mipt.api.entities.comment.models.Comment;
+import me.kruase.mipt.api.entities.comment.models.CommentId;
+import me.kruase.mipt.api.entities.comment.models.CommentTest;
+import me.kruase.mipt.api.entities.comment.models.NewComment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+public abstract class CommentRepositoryTest<I extends CommentRepository> {
+    I repository;
+
+    ArticleId articleId1;
+    ArticleId articleId2;
+    NewComment newComment1;
+    NewComment newComment2;
+    NewComment newComment3;
+    NewComment newComment4;
+    Comment referenceComment1;
+    Comment referenceComment2;
+    Comment referenceComment3;
+    CommentId invalidCommentId;
+
+    abstract I getImplementation();
+
+    @BeforeEach
+    void setUp() {
+        repository = getImplementation();
+
+        articleId1 = new ArticleId(123);
+        articleId2 = new ArticleId(456);
+
+        newComment1 = new NewComment(articleId1, "content_1");
+        newComment2 = new NewComment(articleId1, "content_3");
+        newComment3 = new NewComment(articleId2, "content_2");
+        newComment4 = new NewComment(articleId2, "content_4");
+
+        CommentId commentId1 = repository.create(newComment1);
+        CommentId commentId2 = repository.create(newComment2);
+        CommentId commentId3 = repository.create(newComment3);
+
+        referenceComment1 = new Comment(commentId1, newComment1);
+        referenceComment2 = new Comment(commentId2, newComment2);
+        referenceComment3 = new Comment(commentId3, newComment3);
+
+        invalidCommentId = new CommentId(0);
+    }
+
+    @Test
+    void testFindById() {
+        Comment foundComment1 = repository.findById(referenceComment1.id());
+        Comment foundComment2 = repository.findById(referenceComment2.id());
+        Comment foundComment3 = repository.findById(referenceComment3.id());
+
+        CommentTest.assertDeepEquals(foundComment1, referenceComment1);
+        CommentTest.assertDeepEquals(foundComment2, referenceComment2);
+        CommentTest.assertDeepEquals(foundComment3, referenceComment3);
+    }
+
+    @Test
+    void testFindByIdThrows() {
+        assertThrows(
+                CommentNotFoundException.class,
+                () -> repository.findById(invalidCommentId)
+        );
+    }
+
+    @Test
+    void testCreate() {
+        CommentId createdCommentId = repository.create(newComment4);
+
+        Comment foundComment = repository.findById(createdCommentId);
+
+        CommentTest.assertDeepEquals(foundComment, new Comment(createdCommentId, newComment4));
+    }
+
+    @Test
+    void testDelete() {
+        repository.delete(referenceComment1.id());
+
+        assertThrows(
+                CommentNotFoundException.class,
+                () -> repository.findById(referenceComment1.id())
+        );
+        assertDoesNotThrow(() -> repository.findById(referenceComment2.id()));
+        assertDoesNotThrow(() -> repository.findById(referenceComment3.id()));
+    }
+
+    @Test
+    void testDeleteThrows() {
+        assertThrows(
+                CommentNotFoundException.class,
+                () -> repository.delete(invalidCommentId)
+        );
+    }
+
+    @Test
+    void testDeleteAllByArticleId() {
+        repository.deleteAllByArticleId(articleId1);
+
+        assertThrows(
+                CommentNotFoundException.class,
+                () -> repository.findById(referenceComment1.id())
+        );
+        assertThrows(
+                CommentNotFoundException.class,
+                () -> repository.findById(referenceComment2.id())
+        );
+        assertDoesNotThrow(() -> repository.findById(referenceComment3.id()));
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/entities/comment/repositories/InMemoryCommentRepositoryTest.java
+++ b/src/test/java/me/kruase/mipt/api/entities/comment/repositories/InMemoryCommentRepositoryTest.java
@@ -1,0 +1,9 @@
+package me.kruase.mipt.api.entities.comment.repositories;
+
+
+class InMemoryCommentRepositoryTest extends CommentRepositoryTest<InMemoryCommentRepository> {
+    @Override
+    InMemoryCommentRepository getImplementation() {
+        return new InMemoryCommentRepository();
+    }
+}

--- a/src/test/java/me/kruase/mipt/api/util/SimpleHttpClient.java
+++ b/src/test/java/me/kruase/mipt/api/util/SimpleHttpClient.java
@@ -1,0 +1,62 @@
+package me.kruase.mipt.api.util;
+
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+
+public final class SimpleHttpClient {
+    private static final HttpResponse.BodyHandler<String> charsetHandler =
+            HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8);
+
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    public HttpResponse<String> get(String url) throws IOException, InterruptedException {
+        return client.send(
+                getBaseBuilder(url)
+                        .GET()
+                        .build(),
+                charsetHandler
+        );
+    }
+
+    public HttpResponse<String> post(String url, String body)
+            throws IOException, InterruptedException {
+        return client.send(
+                getBaseBuilder(url)
+                        .POST(BodyPublishers.ofString(body))
+                        .build(),
+                charsetHandler
+        );
+    }
+
+    public HttpResponse<String> put(String url, String body)
+            throws IOException, InterruptedException {
+        return client.send(
+                getBaseBuilder(url)
+                        .PUT(BodyPublishers.ofString(body))
+                        .build(),
+                charsetHandler
+        );
+    }
+
+    public HttpResponse<String> delete(String url) throws IOException, InterruptedException {
+        return client.send(
+                getBaseBuilder(url)
+                        .DELETE()
+                        .build(),
+                charsetHandler
+        );
+    }
+
+    private HttpRequest.Builder getBaseBuilder(String url) {
+        return HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .setHeader("Content-Type", "application/json");
+    }
+}


### PR DESCRIPTION
well...
задание оказалось весьма противоречивое, особенно момент про то, что `Comment` должны были храниться как проперти `Article`, и при этом у `Comment`-ов должен был быть свой репозиторий (с доступом по айди и тд)...
итого это нормально не ложится ни в SQL, ни в NoSQL парадигму))

но я со своим перфекционизмом приложил кучу усилий, чтобы спроектировать все это дело максимально красиво и логично
и, видимо, этот перфекционизм очень больно выстрелил мне в ногу в плане потраченного времени на это чудо... вышло почти 3к строк)))
так что очень сильно прошу оценить по достоинству :)

пара замечаний о дизайне и зависимостях в репозиториях:
- `ArticleRepository` зависит от `CommentRepository` для единственной цели - симуляции поведения `ON DELETE CASCADE` (которая по-хорошему выполняется на уровне БД, так что я ее опустил в самый нижний слой иерархии)
- `CommentService` зависит не только от `CommentRrpository`, но и от `ArticleRepository`, потому что при добавлении комментария его (согласно тз) надо добавить и в сущность `Article`... и там из-за этого получилась громоздкая обработка ошибок :(